### PR TITLE
Test under JDK 25, not JDK 25-ea

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        java: [ '17', '21', '24', '25-ea' ]
+        java: [ '17', '21', '24', '25' ]
 
     steps:
     - uses: actions/checkout@v5

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,6 +1,6 @@
 name: Java CI with Gradle
 
-on: [push, pull_request]
+on: [push, pull_request]   # yamllint disable-line rule:truthy
 
 jobs:
   build:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        java: [ '17', '21', '24', '25' ]
+        java: ['17', '21', '24', '25']
 
     steps:
     - uses: actions/checkout@v5

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -12,20 +12,20 @@ jobs:
         java: ['17', '21', '24', '25']
 
     steps:
-    - uses: actions/checkout@v5
-      with:
-        fetch-depth: 1
-        show-progress: false
-    - name: Set up JDK
-      uses: actions/setup-java@v5
-      with:
-        distribution: 'temurin'
-        java-version: ${{ matrix.java }}
-        check-latest: true
-        cache: 'gradle'
-    - name: ./gradlew build javadoc
-      run: ./gradlew build
-    - name: ./gradlew requireJavadoc
-      run: ./gradlew requireJavadoc
-    - name: ./gradlew spotlessCheck
-      run: ./gradlew spotlessCheck
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+          show-progress: false
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+          check-latest: true
+          cache: 'gradle'
+      - name: ./gradlew build javadoc
+        run: ./gradlew build
+      - name: ./gradlew requireJavadoc
+        run: ./gradlew requireJavadoc
+      - name: ./gradlew spotlessCheck
+        run: ./gradlew spotlessCheck


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI configuration updated to run on stable Java versions 17, 21, 24, and 25 (early-access removed) and workflow formatting cleaned up. This streamlines builds and improves pipeline consistency; no changes to product behavior, public APIs, or user workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->